### PR TITLE
Update lucide-react and GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -265,7 +265,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: build
 
@@ -507,7 +507,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: build
 
@@ -728,7 +728,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "embla-carousel-react": "^8.5.2",
                 "framer-motion": "^12.23.25",
                 "input-otp": "^1.4.2",
-                "lucide-react": "^0.555.0",
+                "lucide-react": "^0.556.0",
                 "react": "^19.2.1",
                 "react-day-picker": "^9.6.7",
                 "react-dom": "^19.2.1",
@@ -5501,9 +5501,9 @@
             }
         },
         "node_modules/lucide-react": {
-            "version": "0.555.0",
-            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
-            "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+            "version": "0.556.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.556.0.tgz",
+            "integrity": "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==",
             "license": "ISC",
             "peerDependencies": {
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "embla-carousel-react": "^8.5.2",
         "framer-motion": "^12.23.25",
         "input-otp": "^1.4.2",
-        "lucide-react": "^0.555.0",
+        "lucide-react": "^0.556.0",
         "react": "^19.2.1",
         "react-day-picker": "^9.6.7",
         "react-dom": "^19.2.1",


### PR DESCRIPTION
Bump lucide-react from 0.555.0 to 0.556.0 in package.json and package-lock.json. Update actions/download-artifact from v4 to v6 in ci-cd.yml for improved compatibility and security.

**CI/CD Workflow Dependency Updates:**

* Updated the `actions/download-artifact` GitHub Action from version `v4` to `v6` in three separate job steps in `.github/workflows/ci-cd.yml` to use the latest version and maintain workflow stability. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L268-R268) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L510-R510) [[3]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L731-R731)

**Frontend Dependency Update:**

* Upgraded the `lucide-react` package from version `0.555.0` to `0.556.0` in `package.json` to incorporate the latest icons and improvements.